### PR TITLE
Stage join not auto join

### DIFF
--- a/groups/repl_all
+++ b/groups/repl_all
@@ -11,6 +11,11 @@ repl_handoff_deadlock_keylist
 repl_location_failures
 repl_fs_bench
 repl_fs_stat_caching
+repl_rt_cascading_rtq
+repl_rt_enqueue_http
+repl_rt_heartbeat
+repl_rt_overload
+repl_rt_pending
 replication2
 replication2_console_tests
 replication2_fsschedule
@@ -21,10 +26,5 @@ replication2_ssl
 replication
 replication_ssl
 replication_stats
-repl_rt_cascading_rtq
-repl_rt_enqueue_http
-repl_rt_heartbeat
-repl_rt_overload
-repl_rt_pending
 verify_counter_repl
 verify_dvv_repl

--- a/tests/repl_util.erl
+++ b/tests/repl_util.erl
@@ -58,7 +58,8 @@ make_cluster(Nodes) ->
     [First|Rest] = Nodes,
     ?assertEqual(ok, rt:wait_until_nodes_ready(Nodes)),
     [rt:wait_for_service(N, riak_kv) || N <- Nodes],
-    [rt:join(Node, First) || Node <- Rest],
+    [rt:staged_join(Node, First) || Node <- Rest],
+    rt:plan_and_commit(First),
     ?assertEqual(ok, rt:wait_until_no_pending_changes(Nodes)).
 
 name_cluster(Node, Name) ->


### PR DESCRIPTION
repl_util should use staged join not auto join.  Will resolve problems whereby an interim ring change can be lead to an update to entropy_info (wiping a last rebuild status) without the vnode/aae-keystore ever going up/down - so they remain as waiting for rebuild